### PR TITLE
Fix denoise formula in CaloScore

### DIFF
--- a/src/CaloScore.py
+++ b/src/CaloScore.py
@@ -230,7 +230,7 @@ class CaloScore(keras.Model):
         z = tf.random.normal((tf.shape(layer)), dtype=tf.float32)
         perturbed_x = alpha * layer + z * sigma            
         score = self.model_layer([perturbed_x, random_t, cond])
-        denoise = alpha_reshape * z - sigma * layer
+        denoise = alpha * z - sigma * layer
         losses = tf.square(score - denoise)
         loss_layer = tf.reduce_mean(losses)
 


### PR DESCRIPTION
## Summary
- correct denoising formula in `test_step`

## Testing
- `python` script attempted to train a dummy model with validation data (fails: ModuleNotFoundError: No module named 'keras.src.engine')

------
https://chatgpt.com/codex/tasks/task_b_6856cb965cd8832da3531eb1288032cd